### PR TITLE
use diskutil to pick APFS Container

### DIFF
--- a/nix-quick-install.sh
+++ b/nix-quick-install.sh
@@ -33,7 +33,7 @@ elif [[ "$sys" =~ .*-darwin ]]; then
   /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B &>/dev/null \
     || /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t &>/dev/null \
     || echo "warning: failed to execute apfs.util"
-  diskutil apfs addVolume disk1 APFS nix -mountpoint /nix
+  diskutil apfs addVolume $(diskutil list | grep "APFS Container Scheme" | grep -oh disk[0-9]) nix -mountpoint /nix
   mdutil -i off /nix
   chown $USER /nix
 EOF


### PR DESCRIPTION
The APFS disk identifier in a MacOS VM may not be disk1; in our use case (shapehq/tartelet runners on MacStadium hosts) it ends up being disk4.  This line might be better at determining which disk to select in non-github-provided runners (or if GH changes up their vm structure).

This should be tested and could be made more robust.